### PR TITLE
Added keyword "Go To URL"

### DIFF
--- a/src/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/src/AppiumLibrary/keywords/_applicationmanagement.py
@@ -128,6 +128,16 @@ class _ApplicationManagementKeywords(KeywordGroup):
     def switch_to_context(self, context_name):
         """Switch to a new context"""
         self._current_application().switch_to.context(context_name)
+        
+    def go_to_url(self, url):
+        """
+        Opens URL in default web browser. 
+        
+        Example:
+        | Open Application  | http://localhost:4755/wd/hub | platformName=iOS | platformVersion=7.0 | deviceName='iPhone Simulator' | browserName=Safari |
+        | Go To URL         | http://m.webapp.com          |
+        """
+        self._current_application().get(url)
 
     # Private
 


### PR DESCRIPTION
When the current application is the default web browser, "Go To URL" causes the browser to send a request to the user specified URL and display the response.

I needed this keyword for automated testing of an existing website in a mobile web browser and thought it would be useful for others.