### PR TITLE
Add 'press_at' in keywords/_touch.py

### DIFF
--- a/src/AppiumLibrary/keywords/_touch.py
+++ b/src/AppiumLibrary/keywords/_touch.py
@@ -74,3 +74,10 @@ class _TouchKeywords(KeywordGroup):
             action.tap(x=float(x), y=float(y)).perform()
         except:
             assert False, "Can't click on a point at (%s,%s)" % (x,y)
+
+    def press_at(self, coordinate_X, coordinate_Y):
+        """ Press at a certain coordinate """
+        self._info("Pressing at (%s, %s)." % (coordinate_X, coordinate_Y))
+        driver = self._current_application()
+        action = TouchAction(driver)
+        action.press(x=coordinate_X, y=coordinate_Y).release().perform()

--- a/src/AppiumLibrary/keywords/_touch.py
+++ b/src/AppiumLibrary/keywords/_touch.py
@@ -75,8 +75,8 @@ class _TouchKeywords(KeywordGroup):
         except:
             assert False, "Can't click on a point at (%s,%s)" % (x,y)
 
-    def press_at(self, coordinate_X, coordinate_Y):
-        """ Press at a certain coordinate """
+    def click_element_at_coordinates(self, coordinate_X, coordinate_Y):
+        """ click element at a certain coordinate """
         self._info("Pressing at (%s, %s)." % (coordinate_X, coordinate_Y))
         driver = self._current_application()
         action = TouchAction(driver)


### PR DESCRIPTION
Sometimes it is the only way to click at a certain coordinate to test
some HTML5 pages. And I tried 'click at point', but it did not work.