### PR TITLE
convert to string before comparing on element_name_should_be keyword

### DIFF
--- a/src/AppiumLibrary/keywords/_element.py
+++ b/src/AppiumLibrary/keywords/_element.py
@@ -147,7 +147,7 @@ class _ElementKeywords(KeywordGroup):
 
     def element_name_should_be(self, locator, expected):
         element = self._element_find(locator, True, True)
-        if expected != element.get_attribute('name'):
+        if str(expected) != str(element.get_attribute('name')):
             raise AssertionError("Element '%s' name should be '%s' "
                                  "but it is '%s'." % (locator, expected, element.get_attribute('name')))
         self._info("Element '%s' name is '%s' " % (locator, expected))

--- a/src/AppiumLibrary/keywords/_element.py
+++ b/src/AppiumLibrary/keywords/_element.py
@@ -154,7 +154,7 @@ class _ElementKeywords(KeywordGroup):
 
     def element_value_should_be(self, locator, expected):
         element = self._element_find(locator, True, True)
-        if expected != element.get_attribute('value'):
+        if str(expected) != str(element.get_attribute('value')):
             raise AssertionError("Element '%s' value should be '%s' "
                                  "but it is '%s'." % (locator, expected, element.get_attribute('value')))
         self._info("Element '%s' value is '%s' " % (locator, expected))


### PR DESCRIPTION
Sometimes, when I use this keyword, I got the following error message:
Element '//UIAApplication[1]/UIAWindow[2]/UIATableView[1]/UIATableCell[2]/UIAStaticText[2]' name should be '12' but it is '12'.

My current solution is to avoid comparing different type of variable, I just converted them to String variable then make comparison.